### PR TITLE
Add Allow-Length

### DIFF
--- a/draft-ietf-partial-content-uploads.md
+++ b/draft-ietf-partial-content-uploads.md
@@ -172,7 +172,7 @@ Sunset: Mon, 13 Nov 2023 00:00:00 GMT
 
 The PATCH method MUST be used to update partial content. Unlike other uses of PATCH, an origin server MUST complete this operation idempotently. Given the entity tag provided by the client and the fact that the required storage space has already been allocated, the origin server has enough information to safely fulfill the request idempotently. This behavior is true even if multiple client requests occur concurrently or overlap in content range.
 
-If the origin server successfully updates the specified content range and more content is expected, then it MUST respond with 202 (Accepted). If the origin server determines no further content is expected, then it MUST respond with 201 (Created) and Content-Location. Content-Location indicates the URL where the client can retrieve the resource with a GET request, which MAY not previously be known to the client. If the Content-Disposition header field contained the modification-date parameter, then the origin server MUST also return this value in the response Last-Modified header field.
+If the origin server successfully updates the specified content range and more content is expected, then it MUST respond with 202 (Accepted); otherwise, the server MUST complete the transfer as described in {{complete-transfer}}. If the Content-Disposition header field contained the modification-date parameter, then the origin server MUST also return this value in the response Last-Modified header field.
 
 ## Content-Range Header Field
 
@@ -202,9 +202,9 @@ If the server is unable to fulfill the request because the allocated storage for
 
 Retrying large content transfers can strain network resources and are likely to have high latency. If the origin server is aware that the storage resource is temporarily unavailable, it is RECOMMENDED that it automatically retry copying the transferred content. The number of times the server retries, or whether that server retries at all, is at the discretion of the server.
 
-## Completing the Transfer
+## Completing the Transfer {#complete-transfer}
 
-To complete a transfer, a client MUST send all the corresponding content ranges. A client MAY vary the size of each transfer; for example, it may increase or decrease the content range based on available network bandwidth. A server knows that the transfer is complete when it has received transfers from a client that contain contiguous content ranges up to the size of the total content, potentially overlapping.
+To complete a transfer, a client MUST send all the corresponding content ranges. A client MAY vary the size of each transfer; for example, it may increase or decrease the content range based on available network bandwidth. A server knows that the transfer is complete when it has received transfers from a client that contain contiguous content ranges up to the size of the total content, potentially overlapping. If the origin server determines no further content is expected, then it MUST respond with 201 (Created) and Content-Location. Content-Location indicates the URL where the client can retrieve the resource with a GET request, which MAY not previously be known to the client.
 
 A server SHOULD NOT be stateful. A server, however, MAY choose to store the start and end position of each content range received in external storage such as a file or database. The exact mechanism used to implement this behavior is at the discretion of the server. Once the server has made the decision that all of the content has been transferred, it MAY allow access to the resource via the GET method that is indicated in Content-Location.
 

--- a/draft-ietf-partial-content-uploads.md
+++ b/draft-ietf-partial-content-uploads.md
@@ -122,7 +122,7 @@ The modification-date parameter is OPTIONAL and has the same meaning as defined 
 
 ## The Allow-Length Header Field {#allow-length}
 
-The Allow-Length response header field allows a server to communicate the allowable length of content. It provides information to clients that enables them to control delimiting framing as they send partial content to the server. It is RECOMMENDED that an origin server return the Allow-Length header when a resource is provisioned for a transfer.
+The Allow-Length response header field allows a server to communicate the allowable length of content. It provides information to clients that enables them to delimit framing as they send partial content to the server. It is RECOMMENDED that an origin server return the Allow-Length header field when a resource is provisioned for a transfer.
 
 ~~~~
 Content-Length = 1*DIGIT
@@ -136,7 +136,7 @@ Allow-Length: 10000000
 
 In the absence of the Allow-Length header field, a client is required to know the maximum length through out-of-band knowledge such as publicly documented policy or through probing requests until a suitable length is determined.
 
-An origin server MAY choose to return Allow-Length in a HEAD or OPTIONS request for a client that did not persist the value and resumes a transfer at a later time. The specified Allow-Length SHOULD NOT change for the lifetime of the transfer. If the value does change during a transfer, then the origin server SHOULD support the HEAD method, OPTIONS method, or both, which will respond with an updated Allow-Length header field.
+An origin server MAY choose to return Allow-Length in a HEAD or OPTIONS request for a client that did not persist the value and resumes a transfer at a later time. The specified Allow-Length SHOULD NOT change for the lifetime of a transfer. If the value does change during a transfer, then the origin server SHOULD support the HEAD method, OPTIONS method, or both, that SHALL respond with an updated Allow-Length header field.
 
 ## Resource Contention
 
@@ -192,7 +192,7 @@ If-Match is a REQUIRED header field. The If-Match header field MUST contain the 
 
 ## Expect Header Field
 
-Expect is an OPTIONAL header field and has the same meaning as defined in Section 10.1.1 of {{!RFC9110}}. Partial content uploads can still be large. Clients SHOULD send the 100-Continue expectation to ensure the server is willing to accept the size of the content being sent. If the client sends more partial content than the server is willing to accept in a single request, it MUST respond with 413 (Payload Too Large). The server SHOULD also respond with the Allow-Length header ({{allow-length}}) to indicate the maximum length allowed by the server.
+Expect is an OPTIONAL header field and has the same meaning as defined in Section 10.1.1 of {{!RFC9110}}. Partial content uploads can still be large. Clients SHOULD send the 100-Continue expectation to ensure the server is willing to accept the size of the content being sent. If the client sends more partial content than the server is willing to accept in a single request, it MUST respond with 413 (Payload Too Large). The server SHOULD also respond with the Allow-Length header field ({{allow-length}}) to indicate the maximum length allowed by the server.
 
 ## Resource Contention
 

--- a/draft-ietf-partial-content-uploads.md
+++ b/draft-ietf-partial-content-uploads.md
@@ -120,7 +120,7 @@ The "filename" and "filename*" parameters are OPTIONAL parameters that have the 
 
 The modification-date parameter is OPTIONAL and has the same meaning as defined in Section 2.5 of {{!RFC2183}}. When the client does not specify the modification-date parameter, the current date and time on the origin server MAY be used if the server has a clock.
 
-## The Allow-Length Header Field
+## The Allow-Length Header Field {#allow-length}
 
 The Allow-Length response header field allows a server to communicate the allowable length of content. It provides information to clients that enables them to control delimiting framing as they send partial content to the server. It is RECOMMENDED that an origin server return the Allow-Length header when a resource is provisioned for a transfer.
 


### PR DESCRIPTION
- Adds the definition for the `Allow-Length` header field
- Reorganizes the text for _Completing the Transfer_